### PR TITLE
Conform sizeof to kernel style + uniformity.

### DIFF
--- a/src/final/gotemp.c
+++ b/src/final/gotemp.c
@@ -182,7 +182,7 @@ static int gotemp_probe(struct usb_interface *interface,
 	struct usb_endpoint_descriptor *endpoint = NULL;
 	size_t buffer_size = 0;
 
-	gdev = kzalloc(sizeof(struct gotemp), GFP_KERNEL);
+	gdev = kzalloc(sizeof(*gdev), GFP_KERNEL);
 	if (gdev == NULL) {
 		dev_err(&interface->dev, "Out of memory\n");
 		goto error;

--- a/src/step-3/gotemp.c
+++ b/src/step-3/gotemp.c
@@ -25,7 +25,7 @@ static int gotemp_probe(struct usb_interface *interface,
 	struct usb_device *udev = interface_to_usbdev(interface);
 	struct gotemp *gdev;
 
-	gdev = kzalloc(sizeof(struct gotemp), GFP_KERNEL);
+	gdev = kzalloc(sizeof(*gdev), GFP_KERNEL);
 	if (gdev == NULL) {
 		dev_err(&interface->dev, "Out of memory\n");
 		return -ENOMEM;

--- a/src/step-4/gotemp.c
+++ b/src/step-4/gotemp.c
@@ -36,7 +36,7 @@ static int gotemp_probe(struct usb_interface *interface,
 	struct gotemp *gdev;
 	int retval;
 
-	gdev = kzalloc(sizeof(struct gotemp), GFP_KERNEL);
+	gdev = kzalloc(sizeof(*gdev), GFP_KERNEL);
 	if (gdev == NULL) {
 		dev_err(&interface->dev, "Out of memory\n");
 		return -ENOMEM;

--- a/src/step-5/gotemp.c
+++ b/src/step-5/gotemp.c
@@ -78,7 +78,7 @@ static int gotemp_probe(struct usb_interface *interface,
 	struct gotemp *gdev;
 	int retval;
 
-	gdev = kzalloc(sizeof(struct gotemp), GFP_KERNEL);
+	gdev = kzalloc(sizeof(*gdev), GFP_KERNEL);
 	if (gdev == NULL) {
 		dev_err(&interface->dev, "Out of memory\n");
 		return -ENOMEM;

--- a/src/step-6/gotemp.c
+++ b/src/step-6/gotemp.c
@@ -135,7 +135,7 @@ static int gotemp_probe(struct usb_interface *interface,
 	int retval = -ENOMEM;
 	size_t buffer_size;
 
-	gdev = kzalloc(sizeof(struct gotemp), GFP_KERNEL);
+	gdev = kzalloc(sizeof(*gdev), GFP_KERNEL);
 	if (gdev == NULL) {
 		dev_err(&interface->dev, "Out of memory\n");
 		return -ENOMEM;


### PR DESCRIPTION
Changing sizeof(struct name) to sizeof(*obj) for the sake of uniformity with
the style in the code as well as the recommended Kernel style.
